### PR TITLE
V1.0 of spanish translation

### DIFF
--- a/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings.xml
+++ b/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings.xml
@@ -1,0 +1,100 @@
+<resources>
+    <string name="app_name">Genshin Wish Simulator</string>
+
+    <!-- region Buttons, Labels, Descriptions etc -->
+    <string name="total_count">Deseos totales: %d</string>
+    <string name="total_spent">Est. ~$%d (USD)</string>
+    <string name="fate_points">Puntos del destino: %1$d/%2$d</string>
+    <string name="chart_course">Senda divina</string>
+    <string name="remove_course">Cancelar selección</string>
+    <string name="details">Detalles</string>
+    <string name="yes">Si</string>
+    <string name="no">No</string>
+    <string name="okay">Okay</string>
+    <string name="cancel">Cancelar</string>
+    <string name="close">Cerrar</string>
+    <string name="skip">Saltar</string>
+    <string name="more">Más</string>
+    <string name="hide">Ocultar</string>
+    <string name="maxed_brackets">(MÁXIMO)</string>
+    <string name="tap_anywhere_to_skip">Presione en cualquier lugar para saltar animación</string>
+    <string name="n_starglitter">%d Brillo Estelar</string>
+    <string name="n_extra">%d extra</string>
+    <string name="n_wishes">%s deseos</string>
+    <string name="constellation_n">C%s</string>
+    <string name="wish">Desear x1</string>
+    <string name="wish_ten">Desear x10</string>
+    <string name="wish_custom">Desear x%s</string>
+    <string name="reset">Reiniciar</string>
+    <string name="settings">Configuración</string>
+    <string name="total_wishes">🌠 Deseos Totales: %d</string>
+    <string name="total_est_cost">💸 Costo Est. (USD): $%d</string>
+    <string name="primogems">💎 Protogemas: %d</string>
+    <string name="masterless_glitter">✨ Brillo estelar: %s</string>
+    <string name="five_star_count">🌟 Cantidad de Cinco Estrellas: %1$d (%2$.3f%%)</string>
+    <string name="four_star_count">⭐ Cantidad de Cuatro Estrellas: %1$d (%2$.3f%%)</string>
+    <string name="show_wish_animation">Mostrar animación de deseos</string>
+    <string name="most_recent_wishes">🌠 Deseos más recientes</string>
+    <string name="wish_history">🕒 Historial de Deseos</string>
+    <string name="no_wishes_yet">Ningún deseo todavía</string>
+    <string name="mute_sounds">Silenciar sonidos</string>
+    <string name="skip_meteor_only">Saltar solo la animación del meteoro</string>
+    <string name="clear_all_results">Borrar todos los resultados de los deseos</string>
+    <string name="custom_wish_amount">Cantidad personalizada de deseos: </string>
+    <string name="are_you_sure_clear_all_wish">¿Estás seguro/a de borrar todos los resultados anteriores?</string>
+    <string name="are_you_sure_clear_fate_points">Cambiar la selección reiniciará tus Puntos de Destino a 0. ¿Quieres continuar?</string>
+    <string name="simulator">Simulador</string>
+    <string name="reset_linked_banner_notice">Este banner está enlazado con %1$s. Al realizar esta acción se reiniciarán ambos banners.</string>
+    <string name="inventory">Inventario</string>
+    <string name="view_inventory">Ver Inventario</string>
+    <!-- endregion -->
+
+    <!-- region Pity Info -->
+    <string name="pity_info_four_star">Deseos hasta el próximo pity de 4-estrellas: %d</string>
+    <string name="pity_info_five_star">Deseos hasta el próximo pity de 5-estrellas: %d</string>
+    <string name="next_five_star_100">Siguiente 5-estrellas: 100%% de ser %s</string>
+    <string name="next_five_star_5050">Siguiente 5-estrellas: 50%% de ser %s</string>
+    <string name="next_five_star_75_featured">Siguiente 5-estrellas: 75% de ser promocional</string>
+    <string name="next_five_star_100_featured">Siguiente 5-estrellas: 100% de ser promocional</string>
+    <!-- endregion -->
+
+    <!-- region Archive -->
+    <string name="view_archived_banners">Ver banners archivados</string>
+    <string name="archived_banners">Banners Archivados</string>
+    <string name="hide_banner_title">¿Ocultar este banner?</string>
+    <string name="hide_banner_desc">Este banner será archivado. Si deseas desarchivarlo, por favor ve a Configuración.</string>
+    <string name="hide_inactive_banner_title">¿Ocultar banners inactivos?</string>
+    <string name="hide_inactive_banner_desc">Los banners inactivos serán archivados. Si deseas desarchivarlos, por favor ve a Configuración.</string>
+    <string name="unarchive">Desarchivar</string>
+    <string name="close_archive">Cerrar Archivo</string>
+    <!-- endregion -->
+
+    <!-- region Advanced Settings -->
+    <string name="advanced_settings">Configuración Avanzada</string>
+    <string name="credits">Créditos</string>
+    <string name="thanks_to_the_following_sites">Gracias a los siguientes sitios por hacer este Simulador de Deseos posible. </string>
+    <string name="thanks_to_the_following_contributors">Gracias a los siguientes colaboradores por ayudarme traduciendo la aplicación.</string>
+    <string name="disclaimer">Aviso Legal</string>
+    <string name="not_affiliated_with_mihoyo">Por favor tenga en cuenta que la applicación Genshin Impact Wish Simulator no está afiliada con la empresa miHoYo de ninguna manera.</string>
+    <string name="wishes_are_free">Este es un simulador de deseos hecho con fines de diversión y entretenimiento. <b><font color='#FF4747'>Los deseos realizados aquí no serán reflejados en el juego. </font></b> La aplicación, y los deseos hechos en la misma son gratis y no cuestan nada de dinero.</string>
+    <string name="all_rights_reserved">Todas las imágenes, sonidos, activos, banners, nombres de personajes, términos, etc, son cortesía y propiedad de \'miHoYo\'. No soy propietario de ninguno de ellos. Todos los derechos reservados por \'miHoYo\'.</string>
+    <string name="privacy_policy">Política de privacidad</string>
+    <string name="localization">Localización</string>
+    <string name="localization_description">Si eres desarrollador y te gustaría ayudarme a localizar/traducir esta aplicación, puedes enviar un pull request a %s.</string>
+    <string name="ads">Anuncios</string>
+    <string name="show_ad_description">Hice esta aplicación por diversión en mi tiempo libre, y será siempre gratis de descargar y libre de usar sin anuncios. Si quieres apoyarme, puedes optar por ver los anuncios.</string>
+    <string name="show_ad_description_may_opt_in">Hice esta aplicación por diversión en mi tiempo libre, y será siempre gratis de descargar y libre de usar sin anuncios. Puedes optar por ver los anuncios si lo deseas.</string>
+    <string name="opt_in_to_show_ads">Optar por ver los anuncios</string>
+    <string name="close_page">Cerrar</string>
+    <string name="light_dark_mode">Modo Claro / Oscuro</string>
+    <string name="light">Claro</string>
+    <string name="dark">Oscuro</string>
+    <string name="use_device_settings">Usar configuración del dispositivo</string>
+    <!-- endregion -->
+
+    <!-- region Intro popup -->
+    <string name="i_agree">He leído y acepto todo lo anterior</string>
+    <string name="proceed">Proceder</string>
+    <string name="must_agree_to_terms">Debes aceptar los términos antes de continuar.</string>
+    <!-- endregion -->
+</resources>

--- a/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings.xml
+++ b/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings.xml
@@ -22,9 +22,9 @@
     <string name="n_extra">%d extra</string>
     <string name="n_wishes">%s deseos</string>
     <string name="constellation_n">C%s</string>
-    <string name="wish">Desear x1</string>
-    <string name="wish_ten">Desear x10</string>
-    <string name="wish_custom">Desear x%s</string>
+    <string name="wish">Pedir 1 deseo</string>
+    <string name="wish_ten">Pedir 10 deseos</string>
+    <string name="wish_custom">Pedir %s deseos</string>
     <string name="reset">Reiniciar</string>
     <string name="settings">Configuración</string>
     <string name="total_wishes">🌠 Deseos Totales: %d</string>

--- a/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings_characters.xml
+++ b/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings_characters.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="none" translatable="false" />
+
+    <string name="permanent">Permanente</string>
+
+    <!-- 5* Permanent-->
+    <string name="diluc">Diluc</string>
+    <string name="jean">Jean</string>
+    <string name="keqing">Keqing</string>
+    <string name="mona">Mona</string>
+    <string name="qiqi">Qiqi</string>
+
+    <!-- 5* Event -->
+    <string name="venti">Venti</string>
+    <string name="klee">Klee</string>
+    <string name="tartaglia">Tartaglia</string>
+    <string name="zhongli">Zhongli</string>
+    <string name="albedo">Albedo</string>
+    <string name="ganyu">Ganyu</string>
+    <string name="xiao">Xiao</string>
+    <string name="hutao">Hu Tao</string>
+    <string name="eula">Eula</string>
+    <string name="kazuha">Kazuha</string>
+    <string name="ayaka">Ayaka</string>
+    <string name="kaedehara_kazuha">Kaedehara Kazuha</string>
+    <string name="kamisato_ayaka">Kamisato Ayaka</string>
+    <string name="yoimiya">Yoimiya</string>
+    <string name="raiden_shogun">Raiden Shogun</string>
+    <string name="raiden">Raiden</string>
+    <string name="sangonomiya_kokomi">Sangonomiya Kokomi</string>
+    <string name="kokomi">Kokomi</string>
+    <string name="itto">Itto</string>
+    <string name="arataki_itto">Arataki Itto</string>
+    <string name="shenhe">Shenhe</string>
+
+    <!-- 4* -->
+    <string name="amber">Amber</string>
+    <string name="barbara">Barbara</string>
+    <string name="beidou">Beidou</string>
+    <string name="bennett">Bennett</string>
+    <string name="chongyun">Chongyun</string>
+    <string name="diona">Diona</string>
+    <string name="fischl">Fischl</string>
+    <string name="kaeya">Kaeya</string>
+    <string name="lisa">Lisa</string>
+    <string name="ningguang">Ningguang</string>
+    <string name="noelle">Noelle</string>
+    <string name="razor">Razor</string>
+    <string name="rosaria">Rosaria</string>
+    <string name="sucrose">Sucrose</string>
+    <string name="xiangling">Xiangling</string>
+    <string name="xingqiu">Xingqiu</string>
+    <string name="xinyan">Xinyan</string>
+    <string name="yanfei">Yanfei</string>
+    <string name="sayu">Sayu</string>
+    <string name="kujou_sara">Kujou Sara</string>
+    <string name="thoma">Thoma</string>
+    <string name="gorou">Gorou</string>
+    <string name="yunjin">Yun Jin</string>
+
+</resources>

--- a/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings_weapons.xml
+++ b/GenshinWishSimLocalization/genshinwishsimlib/src/main/res/values-es/strings_weapons.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="weapon">Armas</string>
+
+    <!-- 5* Permanent-->
+    <string name="amos_bow">Arco de Amos</string>
+    <string name="aquila_favonia">Aquila Favonia</string>
+    <string name="lost_prayer">Oración Perdida a los Vientos Sagrados</string>
+    <string name="primordial_spear">Halcón de jade</string>
+    <string name="wolfs_gravestone">Lápida del Lobo</string>
+    <string name="skyward_harp">Alas Celestiales</string>
+    <string name="skyward_atlas">Pergamino Celestial</string>
+    <string name="skyward_blade">Hoja Afilada Celestial</string>
+    <string name="skyward_spine">Púa Celestial</string>
+    <string name="skyward_pride">Orgullo Celestial</string>
+
+    <!-- 5* Event -->
+    <string name="vortex_vanquisher">Lanza Perforanubes</string>
+    <string name="unforged">Espada de la Desidia</string>
+    <string name="memory_of_dust">Candado Terrenal</string>
+    <string name="summit_shaper">Rompemontañas</string>
+    <string name="primordial_cutter">Cortador de Jade Primordial</string>
+    <string name="staff_of_homa">Báculo de Homa</string>
+    <string name="elegy_for_the_end">Elegía del Fin</string>
+    <string name="song_of_broken_pines">Oda de los Pinos</string>
+    <string name="freedom_sworn">Juramento de la Libertad</string>
+    <string name="mistsplitter_reforged">Reflejo de las Tinieblas</string>
+    <string name="thundering_pulse">Agitador del Relámpago</string>
+    <string name="engulfing_lightning">Luz del segador</string>
+    <string name="everlasting_moonglow">Luna Inalterable</string>
+    <string name="polar_star">Estrella Invernal</string>
+    <string name="redhorn_stonethresher">Espadón Cornirojo</string>
+    <string name="calamity_queller">Pacificadora del Desastre</string>
+
+    <!-- 4* Permanent -->
+    <string name="bell">Espada del Tiempo</string>
+    <string name="dragons_bane">Perdición del Dragón</string>
+    <string name="eye_of_perception">Ojo de la Perspicacia</string>
+    <string name="lions_roar">Rugido del León</string>
+    <string name="favonius_warbow">Arco de Favonius</string>
+    <string name="favonius_codex">Códice de Favonius</string>
+    <string name="favonius_lance">Lanza de Favonius</string>
+    <string name="favonius_greatsword">Gran Espada de Favonius</string>
+    <string name="favonius_sword">Espada de Favonius</string>
+    <string name="flute">Flauta</string>
+    <string name="rainslasher">Segadora de la Lluvia</string>
+    <string name="rust">Herrumbre</string>
+    <string name="sacrificial_fragments">Memorias de Sacrificios</string>
+    <string name="sacrificial_bow">Arco del Sacrificio</string>
+    <string name="sacrificial_greatsword">Gran Espada del Sacrificio</string>
+    <string name="sacrificial_sword">Espada del Sacrificio</string>
+    <string name="stringless">Último Acorde</string>
+    <string name="widsith">Sinfonía de los Merodeadores</string>
+
+    <!-- 4* Event -->
+    <string name="lithic_blade">Espada Lítica</string>
+    <string name="lithic_spear">Lanza Lítica</string>
+    <string name="alley_flash">Destello de la Oscuridad</string>
+    <string name="wing_and_song">Vino y poesía</string>
+    <string name="alley_hunter">Cazador de Callejón</string>
+    <string name="mitternachts_waltz">Vals Nocturno</string>
+    <string name="akuoumaru">Rey del Mal</string>
+    <string name="wavebreakers_fin">Aleta Cortaolas</string>
+    <string name="mouuns_moon">Luna de Mouun</string>
+
+    <!-- 3* -->
+    <string name="debate_club">Garrote del Debate</string>
+    <string name="ferrous_shadow">Sombra Férrea</string>
+    <string name="bloodtainted_greatsword">Gran Espada Sangrienta</string>
+    <string name="white_tassel">Borla Blanca</string>
+    <string name="black_tassel">Borla Negra</string>
+    <string name="harbinger_of_dawn">Espada del Alba</string>
+    <string name="cool_steel">Hoja Fría</string>
+    <string name="skyrider_sword">Gran Espada Surcacielos</string>
+    <string name="slingshot">Tirachinas</string>
+    <string name="sharpshooters_oath">Juramento del Arquero</string>
+    <string name="raven_bow">Arco del Cuervo</string>
+    <string name="thrilling_tales_of_dragon_slayers">Cuentos de Cazadores de Dragones</string>
+    <string name="magic_guide">Guía Mágica</string>
+    <string name="emerald_orb">Orbe Esmeralda</string>
+
+</resources>


### PR DESCRIPTION
Notes V1.0:

- For names "wish", "wish_ten" and "wish_custom"-> The right translation for 'wish xN' is 'Pedir xN deseos'. But maybe that's too much text for the buttons. "Desear xN" it's also ok but is not accurate.
- "Est." is the same abbreviation for EN and ES.
- Some names of weapons are really different in spanish, i use to play in that language.
- strings_characters.xml has only one translation: Permanent -> Permanente. But the file is not translatable?. Check if changing this doesn't affect nothing then...
- The enterprise miHoyo in spanish sounds like "mi hoyo" that can be translated as 'my pit/hole', so you may want to keep quotes (\') around that enterprise name, because is a little funny to read that word combinated with others.